### PR TITLE
ParseToJson and ParseToHtml

### DIFF
--- a/fountain.js
+++ b/fountain.js
@@ -211,7 +211,7 @@
 	if (typeof maybeArray == 'undefined') {
 	  maybeArray = []
 	}
-
+    
 	if (Array.isArray(maybeArray)) {
 	  maybeArray.push(stuffToPush);
 	} else {
@@ -418,12 +418,12 @@
   };
 
   var fountain = function (script, callback) {
-	return fountain.parse(script, callback);
+	return fountain.parseToJson(script, callback);
   };
 
-  fountain.parse = function (script, tokens, callback) {
-	return parse(script, tokens, callback);
-  };
+  fountain.parseToJson = parseToJson;
+
+  fountain.parseToHtml = parseToHtml;
 
   if (typeof module !== 'undefined') {
 	module.exports = fountain;

--- a/fountain.js
+++ b/fountain.js
@@ -211,10 +211,11 @@
 	if (typeof maybeArray == 'undefined') {
 	  maybeArray = []
 	}
-    
+
 	if (Array.isArray(maybeArray)) {
 	  maybeArray.push(stuffToPush);
 	} else {
+      console.trace();
 	  throw "First parameter to this function must be a proper array. Instead got: " + JSON.stringify(maybeArray);
 	}
 
@@ -284,7 +285,7 @@
 
         case 'transition':
           //push the current running scene onto the list, and begin a new one
-          scene.dialogue = pushToArray(token.text, {type: "transition", text: token.text});
+          scene.dialogue = pushToArray(scene.dialogue, {type: "transition", text: token.text});
           break;
 
 

--- a/fountain.js
+++ b/fountain.js
@@ -6,279 +6,428 @@
   'use strict';
 
   var regex = {
-    title_page: /^((?:title|credit|author[s]?|source|notes|draft date|date|contact|copyright)\:)/gim,
+	title_page: /^((?:title|credit|author[s]?|source|notes|draft date|date|contact|copyright)\:)/gim,
 
-    scene_heading: /^((?:\*{0,3}_?)?(?:(?:int|ext|est|i\/e)[. ]).+)|^(?:\.(?!\.+))(.+)/i,
-    scene_number: /( *#(.+)# *)/,
+	scene_heading: /^((?:\*{0,3}_?)?(?:(?:int|ext|est|i\/e)[. ]).+)|^(?:\.(?!\.+))(.+)/i,
+	scene_number: /( *#(.+)# *)/,
 
-    transition: /^((?:FADE (?:TO BLACK|OUT)|CUT TO BLACK)\.|.+ TO\:)|^(?:> *)(.+)/,
-    
-    dialogue: /^([A-Z*_]+[0-9A-Z (._\-')]*)(\^?)?(?:\n(?!\n+))([\s\S]+)/,
-    parenthetical: /^(\(.+\))$/,
+	transition: /^((?:FADE (?:TO BLACK|OUT)|CUT TO BLACK)\.|.+ TO\:)|^(?:> *)(.+)/,
 
-    action: /^(.+)/g,
-    centered: /^(?:> *)(.+)(?: *<)(\n.+)*/g,
-        
-    section: /^(#+)(?: *)(.*)/,
-    synopsis: /^(?:\=(?!\=+) *)(.*)/,
+	dialogue: /^([A-Z*_]+[0-9A-Z (._\-')]*)(\^?)?(?:\n(?!\n+))([\s\S]+)/,
+	parenthetical: /^(\(.+\))$/,
 
-    note: /^(?:\[{2}(?!\[+))(.+)(?:\]{2}(?!\[+))$/,
-    note_inline: /(?:\[{2}(?!\[+))([\s\S]+?)(?:\]{2}(?!\[+))/g,
-    boneyard: /(^\/\*|^\*\/)$/g,
+	action: /^(.+)/g,
+	centered: /^(?:> *)(.+)(?: *<)(\n.+)*/g,
 
-    page_break: /^\={3,}$/,
-    line_break: /^ {2}$/,
+	section: /^(#+)(?: *)(.*)/,
+	synopsis: /^(?:\=(?!\=+) *)(.*)/,
 
-    emphasis: /(_|\*{1,3}|_\*{1,3}|\*{1,3}_)(.+)(_|\*{1,3}|_\*{1,3}|\*{1,3}_)/g,
-    bold_italic_underline: /(_{1}\*{3}(?=.+\*{3}_{1})|\*{3}_{1}(?=.+_{1}\*{3}))(.+?)(\*{3}_{1}|_{1}\*{3})/g,
-    bold_underline: /(_{1}\*{2}(?=.+\*{2}_{1})|\*{2}_{1}(?=.+_{1}\*{2}))(.+?)(\*{2}_{1}|_{1}\*{2})/g,
-    italic_underline: /(?:_{1}\*{1}(?=.+\*{1}_{1})|\*{1}_{1}(?=.+_{1}\*{1}))(.+?)(\*{1}_{1}|_{1}\*{1})/g,
-    bold_italic: /(\*{3}(?=.+\*{3}))(.+?)(\*{3})/g,
-    bold: /(\*{2}(?=.+\*{2}))(.+?)(\*{2})/g,
-    italic: /(\*{1}(?=.+\*{1}))(.+?)(\*{1})/g,
-    underline: /(_{1}(?=.+_{1}))(.+?)(_{1})/g,
+	note: /^(?:\[{2}(?!\[+))(.+)(?:\]{2}(?!\[+))$/,
+	note_inline: /(?:\[{2}(?!\[+))([\s\S]+?)(?:\]{2}(?!\[+))/g,
+	boneyard: /(^\/\*|^\*\/)$/g,
 
-    splitter: /\n{2,}/g,
-    cleaner: /^\n+|\n+$/,
-    standardizer: /\r\n|\r/g,
-    whitespacer: /^\t+|^ {3,}/gm
+	page_break: /^\={3,}$/,
+	line_break: /^ {2}$/,
+
+	emphasis: /(_|\*{1,3}|_\*{1,3}|\*{1,3}_)(.+)(_|\*{1,3}|_\*{1,3}|\*{1,3}_)/g,
+	bold_italic_underline: /(_{1}\*{3}(?=.+\*{3}_{1})|\*{3}_{1}(?=.+_{1}\*{3}))(.+?)(\*{3}_{1}|_{1}\*{3})/g,
+	bold_underline: /(_{1}\*{2}(?=.+\*{2}_{1})|\*{2}_{1}(?=.+_{1}\*{2}))(.+?)(\*{2}_{1}|_{1}\*{2})/g,
+	italic_underline: /(?:_{1}\*{1}(?=.+\*{1}_{1})|\*{1}_{1}(?=.+_{1}\*{1}))(.+?)(\*{1}_{1}|_{1}\*{1})/g,
+	bold_italic: /(\*{3}(?=.+\*{3}))(.+?)(\*{3})/g,
+	bold: /(\*{2}(?=.+\*{2}))(.+?)(\*{2})/g,
+	italic: /(\*{1}(?=.+\*{1}))(.+?)(\*{1})/g,
+	underline: /(_{1}(?=.+_{1}))(.+?)(_{1})/g,
+
+	splitter: /\n{2,}/g,
+	cleaner: /^\n+|\n+$/,
+	standardizer: /\r\n|\r/g,
+	whitespacer: /^\t+|^ {3,}/gm
   };
 
   var lexer = function (script) {
-    return script.replace(regex.boneyard, '\n$1\n')
-                 .replace(regex.standardizer, '\n')
-                 .replace(regex.cleaner, '')
-                 .replace(regex.whitespacer, '');
+	return script.replace(regex.boneyard, '\n$1\n')
+				 .replace(regex.standardizer, '\n')
+				 .replace(regex.cleaner, '')
+				 .replace(regex.whitespacer, '');
   };
-     
+
   var tokenize = function (script) {
-    var src    = lexer(script).split(regex.splitter)
-      , i      = src.length, line, match, parts, text, meta, x, xlen, dual
-      , tokens = [];
+	var src    = lexer(script).split(regex.splitter)
+	  , i      = src.length, line, match, parts, text, meta, x, xlen, dual
+	  , tokens = [];
 
-    while (i--) {
-      line = src[i];
-      
-      // title page
-      if (regex.title_page.test(line)) {
-        match = line.replace(regex.title_page, '\n$1').split(regex.splitter).reverse();
-        for (x = 0, xlen = match.length; x < xlen; x++) {
-          parts = match[x].replace(regex.cleaner, '').split(/\:\n*/);
-          tokens.push({ type: parts[0].trim().toLowerCase().replace(' ', '_'), text: parts[1].trim() });
-        }
-        continue;
-      }
+	while (i--) {
+	  line = src[i];
 
-      // scene headings
-      if (match = line.match(regex.scene_heading)) {
-        text = match[1] || match[2];
+	  // title page
+	  if (regex.title_page.test(line)) {
+		match = line.replace(regex.title_page, '\n$1').split(regex.splitter).reverse();
+		for (x = 0, xlen = match.length; x < xlen; x++) {
+		  parts = match[x].replace(regex.cleaner, '').split(/\:\n*/);
+		  tokens.push({ type: parts[0].trim().toLowerCase().replace(' ', '_'), text: parts[1].trim() });
+		}
+		continue;
+	  }
 
-        if (text.indexOf('  ') !== text.length - 2) {
-          if (meta = text.match(regex.scene_number)) {
-            meta = meta[2];
-            text = text.replace(regex.scene_number, '');
-          }
-          tokens.push({ type: 'scene_heading', text: text, scene_number: meta || undefined });
-        }
-        continue;
-      }
+	  // scene headings
+	  if (match = line.match(regex.scene_heading)) {
+		text = match[1] || match[2];
 
-      // centered
-      if (match = line.match(regex.centered)) {
-        tokens.push({ type: 'centered', text: match[0].replace(/>|</g, '') });
-        continue;
-      }
+		if (text.indexOf('  ') !== text.length - 2) {
+		  if (meta = text.match(regex.scene_number)) {
+			meta = meta[2];
+			text = text.replace(regex.scene_number, '');
+		  }
+		  tokens.push({ type: 'scene_heading', text: text, scene_number: meta || undefined });
+		}
+		continue;
+	  }
 
-      // transitions
-      if (match = line.match(regex.transition)) {
-        tokens.push({ type: 'transition', text: match[1] || match[2] });
-        continue;
-      }
-    
-      // dialogue blocks - characters, parentheticals and dialogue
-      if (match = line.match(regex.dialogue)) {
-        if (match[1].indexOf('  ') !== match[1].length - 2) {
-          // we're iterating from the bottom up, so we need to push these backwards
-          if (match[2]) {
-            tokens.push({ type: 'dual_dialogue_end' });
-          }
+	  // centered
+	  if (match = line.match(regex.centered)) {
+		tokens.push({ type: 'centered', text: match[0].replace(/>|</g, '') });
+		continue;
+	  }
 
-          tokens.push({ type: 'dialogue_end' });
+	  // transitions
+	  if (match = line.match(regex.transition)) {
+		tokens.push({ type: 'transition', text: match[1] || match[2] });
+		continue;
+	  }
 
-          parts = match[3].split(/(\(.+\))(?:\n+)/).reverse();
+	  // dialogue blocks - characters, parentheticals and dialogue
+	  if (match = line.match(regex.dialogue)) {
+		if (match[1].indexOf('  ') !== match[1].length - 2) {
+		  // we're iterating from the bottom up, so we need to push these backwards
+		  if (match[2]) {
+			tokens.push({ type: 'dual_dialogue_end' });
+		  }
 
-          for (x = 0, xlen = parts.length; x < xlen; x++) {	
-            text = parts[x];
+		  tokens.push({ type: 'dialogue_end' });
 
-            if (text.length > 0) {
-              tokens.push({ type: regex.parenthetical.test(text) ? 'parenthetical' : 'dialogue', text: text });
-            }
-          }
+		  parts = match[3].split(/(\(.+\))(?:\n+)/).reverse();
 
-          tokens.push({ type: 'character', text: match[1].trim() });
-          tokens.push({ type: 'dialogue_begin', dual: match[2] ? 'right' : dual ? 'left' : undefined });
+		  for (x = 0, xlen = parts.length; x < xlen; x++) {
+			text = parts[x];
 
-          if (dual) {
-            tokens.push({ type: 'dual_dialogue_begin' });
-          }
+			if (text.length > 0) {
+			  tokens.push({ type: regex.parenthetical.test(text) ? 'parenthetical' : 'dialogue', text: text });
+			}
+		  }
 
-          dual = match[2] ? true : false;
-          continue;
-        }
-      }
-      
-      // section
-      if (match = line.match(regex.section)) {
-        tokens.push({ type: 'section', text: match[2], depth: match[1].length });
-        continue;
-      }
-      
-      // synopsis
-      if (match = line.match(regex.synopsis)) {
-        tokens.push({ type: 'synopsis', text: match[1] });
-        continue;
-      }
+		  tokens.push({ type: 'character', text: match[1].trim() });
+		  tokens.push({ type: 'dialogue_begin', dual: match[2] ? 'right' : dual ? 'left' : undefined });
 
-      // notes
-      if (match = line.match(regex.note)) {
-        tokens.push({ type: 'note', text: match[1]});
-        continue;
-      }      
+		  if (dual) {
+			tokens.push({ type: 'dual_dialogue_begin' });
+		  }
 
-      // boneyard
-      if (match = line.match(regex.boneyard)) {
-        tokens.push({ type: match[0][0] === '/' ? 'boneyard_begin' : 'boneyard_end' });
-        continue;
-      }      
+		  dual = match[2] ? true : false;
+		  continue;
+		}
+	  }
 
-      // page breaks
-      if (regex.page_break.test(line)) {
-        tokens.push({ type: 'page_break' });
-        continue;
-      }
-      
-      // line breaks
-      if (regex.line_break.test(line)) {
-        tokens.push({ type: 'line_break' });
-        continue;
-      }
+	  // section
+	  if (match = line.match(regex.section)) {
+		tokens.push({ type: 'section', text: match[2], depth: match[1].length });
+		continue;
+	  }
 
-      tokens.push({ type: 'action', text: line });
-    }
+	  // synopsis
+	  if (match = line.match(regex.synopsis)) {
+		tokens.push({ type: 'synopsis', text: match[1] });
+		continue;
+	  }
 
-    return tokens;
+	  // notes
+	  if (match = line.match(regex.note)) {
+		tokens.push({ type: 'note', text: match[1]});
+		continue;
+	  }
+
+	  // boneyard
+	  if (match = line.match(regex.boneyard)) {
+		tokens.push({ type: match[0][0] === '/' ? 'boneyard_begin' : 'boneyard_end' });
+		continue;
+	  }
+
+	  // page breaks
+	  if (regex.page_break.test(line)) {
+		tokens.push({ type: 'page_break' });
+		continue;
+	  }
+
+	  // line breaks
+	  if (regex.line_break.test(line)) {
+		tokens.push({ type: 'line_break' });
+		continue;
+	  }
+
+	  tokens.push({ type: 'action', text: line });
+	}
+
+	return tokens;
   };
 
   var inline = {
-    note: '<!-- $1 -->',
+	note: '<!-- $1 -->',
 
-    line_break: '<br />',
+	line_break: '<br />',
 
-    bold_italic_underline: '<span class=\"bold italic underline\">$2</span>',
-    bold_underline: '<span class=\"bold underline\">$2</span>',
-    italic_underline: '<span class=\"italic underline\">$2</span>',
-    bold_italic: '<span class=\"bold italic\">$2</span>',
-    bold: '<span class=\"bold\">$2</span>',
-    italic: '<span class=\"italic\">$2</span>',
-    underline: '<span class=\"underline\">$2</span>'
+	bold_italic_underline: '<span class=\"bold italic underline\">$2</span>',
+	bold_underline: '<span class=\"bold underline\">$2</span>',
+	italic_underline: '<span class=\"italic underline\">$2</span>',
+	bold_italic: '<span class=\"bold italic\">$2</span>',
+	bold: '<span class=\"bold\">$2</span>',
+	italic: '<span class=\"italic\">$2</span>',
+	underline: '<span class=\"underline\">$2</span>'
   };
 
   inline.lexer = function (s) {
-    if (!s) {
-      return;
-    }  
+	if (!s) {
+	  return;
+	}
 
-    var styles = [ 'underline', 'italic', 'bold', 'bold_italic', 'italic_underline', 'bold_underline', 'bold_italic_underline' ]
-           , i = styles.length, style, match;
+	var styles = [ 'underline', 'italic', 'bold', 'bold_italic', 'italic_underline', 'bold_underline', 'bold_italic_underline' ]
+		   , i = styles.length, style, match;
 
-    s = s.replace(regex.note_inline, inline.note).replace(/\\\*/g, '[star]').replace(/\\_/g, '[underline]').replace(/\n/g, inline.line_break);
+	s = s.replace(regex.note_inline, inline.note).replace(/\\\*/g, '[star]').replace(/\\_/g, '[underline]').replace(/\n/g, inline.line_break);
 
    // if (regex.emphasis.test(s)) {                         // this was causing only every other occurence of an emphasis syntax to be parsed
-      while (i--) {
-        style = styles[i];
-        match = regex[style];
+	  while (i--) {
+		style = styles[i];
+		match = regex[style];
    
-        if (match.test(s)) {
-          s = s.replace(match, inline[style]);
-        }
-      }
+		if (match.test(s)) {
+		  s = s.replace(match, inline[style]);
+		}
+	  }
    // }
 
-    return s.replace(/\[star\]/g, '*').replace(/\[underline\]/g, '_').trim();
+	return s.replace(/\[star\]/g, '*').replace(/\[underline\]/g, '_').trim();
   };
 
+  var pushToArray = function(maybeArray, stuffToPush) {
+	if (typeof maybeArray == 'undefined') {
+	  maybeArray = []
+	}
+
+	if (Array.isArray(maybeArray)) {
+	  maybeArray.push(stuffToPush);
+	} else {
+	  throw "First parameter to this function must be a proper array. Instead got: " + JSON.stringify(maybeArray);
+	}
+
+	return maybeArray;
+  }
+
   var parse = function (script, toks, callback) {
-    if (callback === undefined && typeof toks === 'function') {
-      callback = toks;
-      toks = undefined;
-    }
-      
-    var tokens = tokenize(script)
-      , i      = tokens.length, token
-      , title, title_page = [], html = [], output;
+	if (callback === undefined && typeof toks === 'function') {
+	  callback = toks;
+	  toks = undefined;
+	}
 
-    while (i--) {
-      token = tokens[i];
-      token.text = inline.lexer(token.text);
+	var tokens = tokenize(script)
+	  , i      = tokens.length, token
+	  , title, output = {};
 
-      switch (token.type) {
-        case 'title': title_page.push('<h1>' + token.text + '</h1>'); title = token.text.replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, ''); break;
-        case 'credit': title_page.push('<p class=\"credit\">' + token.text + '</p>'); break;
-        case 'author': title_page.push('<p class=\"authors\">' + token.text + '</p>'); break;
-        case 'authors': title_page.push('<p class=\"authors\">' + token.text + '</p>'); break;
-        case 'source': title_page.push('<p class=\"source\">' + token.text + '</p>'); break;
-        case 'notes': title_page.push('<p class=\"notes\">' + token.text + '</p>'); break;
-        case 'draft_date': title_page.push('<p class=\"draft-date\">' + token.text + '</p>'); break;
-        case 'date': title_page.push('<p class=\"date\">' + token.text + '</p>'); break;
-        case 'contact': title_page.push('<p class=\"contact\">' + token.text + '</p>'); break;
-        case 'copyright': title_page.push('<p class=\"copyright\">' + token.text + '</p>'); break;
+	output.title_page = {};
+	output.script = []; //script is an array of scenes
 
-        case 'scene_heading': html.push('<h3' + (token.scene_number ? ' id=\"' + token.scene_number + '\">' : '>') + token.text + '</h3>'); break;
-        case 'transition': html.push('<h2>' + token.text + '</h2>'); break;
+	output.tokens = toks ? tokens.reverse() : undefined;
 
-        case 'dual_dialogue_begin': html.push('<div class=\"dual-dialogue\">'); break;
-        case 'dialogue_begin': html.push('<div class=\"dialogue' + (token.dual ? ' ' + token.dual : '') + '\">'); break;
-        case 'character': html.push('<h4>' + token.text + '</h4>'); break;
-        case 'parenthetical': html.push('<p class=\"parenthetical\">' + token.text + '</p>'); break;
-        case 'dialogue': html.push('<p>' + token.text + '</p>'); break;
-        case 'dialogue_end': html.push('</div> '); break;
-        case 'dual_dialogue_end': html.push('</div> '); break;
+	var scene = {}; //the current running scene
+    var dialogue = {}; //the current running dialogue
+    var character = {}; //the current running character
 
-        case 'section': html.push('<p class=\"section\" data-depth=\"' + token.depth + '\">' + token.text + '</p>'); break;
-        case 'synopsis': html.push('<p class=\"synopsis\">' + token.text + '</p>'); break;
+	while (i--) {
+	  token = tokens[i];
+	  token.text = inline.lexer(token.text);
 
-        case 'note': html.push('<!-- ' + token.text + '-->'); break;
-        case 'boneyard_begin': html.push('<!-- '); break;
-        case 'boneyard_end': html.push(' -->'); break;
+	  switch (token.type) {
+		case 'title':
+		  output.title = token.text.replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, '');
+		  output.title_page.title = pushToArray(output.title_page.title, output.title);
+		  break;
+		case 'credit':
+		  output.title_page.credit = pushToArray(output.title_page.credit, token.text);
+		  break;
+		case 'author':
+		case 'authors':
+		  output.title_page.authors = pushToArray(output.title_page.authors, token.text);
+		  break;
+		case 'source':
+		  output.title_page.source = pushToArray(output.title_page.source, token.text);
+		  break;
+		case 'notes':
+		  output.title_page.notes = pushToArray(output.title_page.notes, token.text);
+		  break;
+		case 'draft_date':
+		  output.title_page.draftdate = pushToArray(output.title_page.draftdate, token.text);
+		  break;
+		case 'date':
+		  output.title_page.date = pushToArray(output.title_page.date, token.text);
+		  break;
+		case 'contact':
+		  output.title_page.contact = pushToArray(output.title_page.contact, token.text);
+		  break;
+		case 'copyright':
+		  output.title_page.copyright = pushToArray(output.title_page.copyright, token.text);
+		  break;
 
-        case 'action': html.push('<p>' + token.text + '</p>'); break;
-        case 'centered': html.push('<p class=\"centered\">' + token.text + '</p>'); break;
-        
-        case 'page_break': html.push('<hr />'); break;
-        case 'line_break': html.push('<br />'); break;
-      }
-    }
+		case 'scene_heading':
+          output.script.scenes = pushToArray(output.script.scenes, scene);
+          scene = {};
+          scene.headings = pushToArray(scene.heading,
+              {"scene_number": token.scene_number, "heading": token.text});
+          break;
 
-    output = { title: title, html: { title_page: title_page.join(''), script: html.join('') }, tokens: toks ? tokens.reverse() : undefined };
+        case 'transition':
+          //push the current running scene onto the list, and begin a new one
+          scene.dialogue = pushToArray(token.text, {type: "transition", text: token.text});
+          break;
 
-    if (typeof callback === 'function') {
-      return callback(output);
-    }
 
-    return output;
+        case 'dual_dialogue_begin':
+          dialogue.characters = pushToArray(dialogue.characters, character);
+          scene.dialogue = pushToArray(scene.dialog, dialogue);
+            dialogue = {type: "dual"};
+		  break;
+		case 'dialogue_begin':
+          dialogue.characters = pushToArray(dialogue.characters, character);
+          scene.dialogue = pushToArray(scene.dialog, dialogue);
+          dialogue = {type: (token.dual ? "dual" : '')};
+		  break;
+        case 'character':
+          dialogue.characters = pushToArray(dialogue.characters, character);
+          character = {type: "character", name: token.text};
+		  break;
+		case 'parenthetical':
+          character.dialogue = pushToArray(character.dialogue, {type: "parenthetical", text: token.text});
+		  break;
+		case 'dialogue':
+          character.dialogue = pushToArray(character.dialogue, {type: "dialogue", text: token.text});
+		  break;
+		case 'dialogue_end':
+		case 'dual_dialogue_end':
+          dialogue.characters = pushToArray(dialogue.characters, character);
+          scene.dialogue = pushToArray(scene.dialog, dialogue);
+          dialogue = {};
+		  break;
+
+		case 'section':
+          scene.sections = pushToArray(scene.sections, token.text);
+		  html.push('<p class=\"section\" data-depth=\"' + token.depth + '\">' + token.text + '</p>');
+		  break;
+		case 'synopsis':
+          scene.synopses = pushToArray(scene.synopses, token.text);
+		  html.push('<p class=\"synopsis\">' + token.text + '</p>');
+		  break;
+
+		case 'note':
+		case 'boneyard_begin':
+		case 'boneyard_end':
+            //NO OP
+              break;
+
+		case 'action':
+        case 'centered':
+          scene.actions = pushToArray(scene.actions, token.text);
+		  break;
+
+		case 'page_break':
+		case 'line_break':
+
+            //NO OP
+		  break;
+	  }
+	}
+
+    //ensure we track any dangling state:
+    dialogue.characters = pushToArray(dialogue.characters, character);
+    scene.dialogue = pushToArray(scene.dialog, dialogue);
+    output.script = pushToArray(output.script, scene);
+
+	if (typeof callback === 'function') {
+	  return callback(output);
+	}
+
+	return output;
+  };
+
+
+  var parseToHtml = function (script, toks, callback) {
+	if (callback === undefined && typeof toks === 'function') {
+	  callback = toks;
+	  toks = undefined;
+	}
+
+	var tokens = tokenize(script)
+		, i      = tokens.length, token
+		, title, title_page = [], html = [], output = {};
+
+	while (i--) {
+	  token = tokens[i];
+	  token.text = inline.lexer(token.text);
+
+	  switch (token.type) {
+		case 'title': title_page.push('<h1>' + token.text + '</h1>'); title = token.text.replace('<br />', ' ').replace(/<(?:.|\n)*?>/g, ''); break;
+		case 'credit': title_page.push('<p class=\"credit\">' + token.text + '</p>'); break;
+		case 'author': title_page.push('<p class=\"authors\">' + token.text + '</p>'); break;
+		case 'authors': title_page.push('<p class=\"authors\">' + token.text + '</p>'); break;
+		case 'source': title_page.push('<p class=\"source\">' + token.text + '</p>'); break;
+		case 'notes': title_page.push('<p class=\"notes\">' + token.text + '</p>'); break;
+		case 'draft_date': title_page.push('<p class=\"draft-date\">' + token.text + '</p>'); break;
+		case 'date': title_page.push('<p class=\"date\">' + token.text + '</p>'); break;
+		case 'contact': title_page.push('<p class=\"contact\">' + token.text + '</p>'); break;
+		case 'copyright': title_page.push('<p class=\"copyright\">' + token.text + '</p>'); break;
+
+		case 'scene_heading': html.push('<h3' + (token.scene_number ? ' id=\"' + token.scene_number + '\">' : '>') + token.text + '</h3>'); break;
+		case 'transition': html.push('<h2>' + token.text + '</h2>'); break;
+
+		case 'dual_dialogue_begin': html.push('<div class=\"dual-dialogue\">'); break;
+		case 'dialogue_begin': html.push('<div class=\"dialogue' + (token.dual ? ' ' + token.dual : '') + '\">'); break;
+		case 'character': html.push('<h4>' + token.text + '</h4>'); break;
+		case 'parenthetical': html.push('<p class=\"parenthetical\">' + token.text + '</p>'); break;
+		case 'dialogue': html.push('<p>' + token.text + '</p>'); break;
+		case 'dialogue_end': html.push('</div> '); break;
+		case 'dual_dialogue_end': html.push('</div> '); break;
+
+		case 'section': html.push('<p class=\"section\" data-depth=\"' + token.depth + '\">' + token.text + '</p>'); break;
+		case 'synopsis': html.push('<p class=\"synopsis\">' + token.text + '</p>'); break;
+
+		case 'note': html.push('<!-- ' + token.text + '-->'); break;
+		case 'boneyard_begin': html.push('<!-- '); break;
+		case 'boneyard_end': html.push(' -->'); break;
+
+		case 'action': html.push('<p>' + token.text + '</p>'); break;
+		case 'centered': html.push('<p class=\"centered\">' + token.text + '</p>'); break;
+
+		case 'page_break': html.push('<hr />'); break;
+		case 'line_break': html.push('<br />'); break;
+	  }
+	}
+
+	output = { title: title, html: { title_page: title_page.join(''), script: html.join('') }, tokens: toks ? tokens.reverse() : undefined};
+
+	if (typeof callback === 'function') {
+	  return callback(output);
+	}
+
+	return output;
   };
 
   var fountain = function (script, callback) {
-    return fountain.parse(script, callback);
+	return fountain.parse(script, callback);
   };
-    
+
   fountain.parse = function (script, tokens, callback) {
-    return parse(script, tokens, callback);
+	return parse(script, tokens, callback);
   };
 
   if (typeof module !== 'undefined') {
-    module.exports = fountain;
+	module.exports = fountain;
   } else {
-    this.fountain = fountain;
+	this.fountain = fountain;
   }  
 }).call(this);

--- a/fountain.js
+++ b/fountain.js
@@ -233,7 +233,7 @@
 	  , title, output = {};
 
 	output.title_page = {};
-	output.script = []; //script is an array of scenes
+	output.script = {}; //script is an array of scenes
 
 	output.tokens = toks ? tokens.reverse() : undefined;
 
@@ -347,7 +347,7 @@
     //ensure we track any dangling state:
     dialogue.characters = pushToArray(dialogue.characters, character);
     scene.dialogue = pushToArray(scene.dialog, dialogue);
-    output.script = pushToArray(output.script, scene);
+    output.script.scenes = pushToArray(output.script.scenes, scene);
 
 	if (typeof callback === 'function') {
 	  return callback(output);

--- a/fountain.js
+++ b/fountain.js
@@ -333,7 +333,7 @@
 
 		case 'action':
         case 'centered':
-          scene.actions = pushToArray(scene.actions, {type: "action", text: token.text});
+          scene = pushToArray(scene, {type: "action", text: token.text});
 		  break;
 
 		case 'page_break':

--- a/fountain.js
+++ b/fountain.js
@@ -221,7 +221,7 @@
 	return maybeArray;
   }
 
-  var parse = function (script, toks, callback) {
+  var parseToJson = function (script, toks, callback) {
 	if (callback === undefined && typeof toks === 'function') {
 	  callback = toks;
 	  toks = undefined;


### PR DESCRIPTION
The parser as it existed, gave you an HTML output from the fountain.io format. This is good, but it's not technically a parser so much as a transcoder. Consuming the output programmatically was not possible (not easily at least.)

This change keeps the original parse function renamed to parseToHtml.

It adds a new function called parseToJson which parses the file into a javascript object graph. This allows programmatic access to elements of the script such as dialog, characters, scenes, transitions, etc.

I believe this will be very handy for future users.
